### PR TITLE
Get all volunteerEntries for specific Event (Closes #48)

### DIFF
--- a/src/app/api/event/[_id]/entry/route.ts
+++ b/src/app/api/event/[_id]/entry/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from "next/server";
+import connectDB from "@database/db";
+import VolunteerEntries from "@database/volunteerEntrySchema";
+import Volunteers from "@database/volunteerSchema";
+import VolunteerRoles from "@database/volunteerRoleSchema";
+import eventSchema from "@database/eventSchema";
+
+type IParams = {
+  params: {
+    _id: string;
+  };
+};
+
+
+// GET all volunteer entries for a specific event with expanded volunteer and role data
+
+export async function GET(req: NextRequest, { params }: IParams) {
+
+}

--- a/src/app/api/event/[_id]/entry/route.ts
+++ b/src/app/api/event/[_id]/entry/route.ts
@@ -3,7 +3,6 @@ import connectDB from "@database/db";
 import VolunteerEntries from "@database/volunteerEntrySchema";
 import Volunteers from "@database/volunteerSchema";
 import VolunteerRoles from "@database/volunteerRoleSchema";
-import eventSchema from "@database/eventSchema";
 
 type IParams = {
   params: {
@@ -11,9 +10,43 @@ type IParams = {
   };
 };
 
-
 // GET all volunteer entries for a specific event with expanded volunteer and role data
-
 export async function GET(req: NextRequest, { params }: IParams) {
+  await connectDB();
+  const { _id } = params;
 
+  try {
+    const volunteerEntries = await VolunteerEntries.find({ eventId: _id });
+    const expandedEntries = [];
+
+    for (let i = 0; i < volunteerEntries.length; i++) {
+      const currentEntry = volunteerEntries[i];
+      const expandedVolunteer = await Volunteers.findById(currentEntry.volunteerId, {
+        _id: 1,
+        name: 1,
+        email: 1,
+        languages: 1,
+        active: 1,
+      }).lean()
+
+      const expandedRoles = await VolunteerRoles.find({ _id: { $in: currentEntry.roles } }, {
+        _id: 1,
+        roleName: 1,
+        description: 1,
+        timeslots: 1,
+      }).lean();
+
+      expandedEntries.push({
+        _id: currentEntry._id,
+        eventId: currentEntry.eventId,
+        roles: expandedRoles ?? [],
+        volunteer: expandedVolunteer ?? null,
+        responses: currentEntry.responses,
+      });
+    }
+
+    return NextResponse.json(expandedEntries);
+  } catch (err) {
+    return NextResponse.json({ message: "Error getting expanded entries:", error: err }, { status: 404 });
+  }
 }


### PR DESCRIPTION
## Developer: Adrian Nguyen

Closes #48 

### Pull Request Summary

Creates an API endpoint that returns all volunteer entries with custom expanded data given an event Id.

### Modifications

- /api/event/[_id]/entry/ file created with GET endpoint implemented

### Testing Considerations

Example of what the return data will look like through testing
```
[
    {
        "_id": "663c2fc3d3954490f0c0c852",
        "eventId": "663c2f0ed3954490f0c0c846",
        "roles": [
            {
                "_id": "663c2f51d3954490f0c0c84a",
                "roleName": "Cleanup Volunteer",
                "description": "Help with trash collection.",
                "timeslots": [
                    {
                        "startTime": "2024-05-20T08:00:00.000Z",
                        "endTime": "2024-05-20T12:00:00.000Z",
                        "volunteers": [
                            "663c33c4ea10b03d9ae81595"
                        ],
                        "_id": "663c2f51d3954490f0c0c84b"
                    }
                ]
            }
        ],
        "volunteer": {
            "_id": "663c33c4ea10b03d9ae81595",
            "name": "Adrian Nguyen",
            "email": "hngt.adrian@gmail.com",
            "languages": [
                "English",
                "Vietnamese"
            ],
            "active": true
        },
        "responses": [
            {
                "question": "Are you able to lift 30 pounds?",
                "answer": "Yes",
                "_id": "663c2fc3d3954490f0c0c853"
            },
            {
                "question": "Which areas would you prefer to work in?",
                "answer": "West Side",
                "_id": "663c2fc3d3954490f0c0c854"
            }
        ]
    }
]
```

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers
