### PR TITLE
Admin View Logic & Button

### DIFF
--- a/src/app/components/Calendar.tsx
+++ b/src/app/components/Calendar.tsx
@@ -90,9 +90,11 @@ const Calendar = ({ admin = false }) => {
         <div className={style.buttonContainer}>
           {admin ? (
             <div style={{ display: 'flex', justifyContent: 'space-between', width: '100%' }}>
-            <Button mt={3} colorScheme="teal">
-              <Link href="/admin/profiles">Profile Database</Link>
-            </Button>
+            <Link href="/admin/profiles">
+              <Button mt={3} colorScheme="teal">
+                Profile Database
+              </Button>
+            </Link>
             <Button mt={3} ref={btnRef} onClick={onOpen} colorScheme="teal">
               Add Event
             </Button>

--- a/src/app/components/Calendar.tsx
+++ b/src/app/components/Calendar.tsx
@@ -38,16 +38,6 @@ const Calendar = ({ admin = false }) => {
   const [selectedEventId, setSelectedEventId] = useState("");
   const [detailModalOpen, setDetailModalOpen] = useState(false);
 
-  //User Session Data
-  const { isLoaded, isSignedIn, user } = useUser();
-  const admins = process.env.NEXT_PUBLIC_ADMIN_EMAIL_ADDRESSES?.split(",");
-  if (user && isSignedIn && isLoaded && user.primaryEmailAddress) {
-    if (admins?.includes(user.primaryEmailAddress.emailAddress)) {
-      admin = true;
-    } 
-  }
-
-
   //for event modal
   const { isOpen, onOpen, onClose } = useDisclosure();
   const btnRef = React.useRef(null);

--- a/src/app/components/Calendar.tsx
+++ b/src/app/components/Calendar.tsx
@@ -20,6 +20,8 @@ import {
 import UserEventDetails from "./UserEventDetails";
 import AdminEventDetails from "./AdminEventDetails/AdminEventDetails";
 import CreateEvent from "./CreateEvent/CreateEvent";
+import { useUser } from '@clerk/nextjs';
+import Link from "next/link";
 
 //Interface to define full calendar event format
 interface FullCalendarEvent {
@@ -35,6 +37,16 @@ const Calendar = ({ admin = false }) => {
   >([]);
   const [selectedEventId, setSelectedEventId] = useState("");
   const [detailModalOpen, setDetailModalOpen] = useState(false);
+
+  //User Session Data
+  const { isLoaded, isSignedIn, user } = useUser();
+  const admins = process.env.NEXT_PUBLIC_ADMIN_EMAIL_ADDRESSES?.split(",");
+  if (user && isSignedIn && isLoaded && user.primaryEmailAddress) {
+    if (admins?.includes(user.primaryEmailAddress.emailAddress)) {
+      admin = true;
+    } 
+  }
+
 
   //for event modal
   const { isOpen, onOpen, onClose } = useDisclosure();
@@ -86,9 +98,15 @@ const Calendar = ({ admin = false }) => {
         <style>{calendarStyles}</style>
         <>
         <div className={style.buttonContainer}>
-          <Button mt={3} ref={btnRef} onClick={onOpen} colorScheme="teal">
-            Add Event
-          </Button>
+          {admin ? (
+            <div style={{ display: 'flex', justifyContent: 'space-between', width: '100%' }}>
+            <Button mt={3} colorScheme="teal">
+              <Link href="/admin/profiles">Profile Database</Link>
+            </Button>
+            <Button mt={3} ref={btnRef} onClick={onOpen} colorScheme="teal">
+              Add Event
+            </Button>
+          </div>) : null}
         </div>
         <Modal
           onClose={onClose}
@@ -101,6 +119,7 @@ const Calendar = ({ admin = false }) => {
           <ModalContent>
             <div>
               <ModalCloseButton />
+
               <CreateEvent 
                 events={events} 
                 setEvents={setEvents} 

--- a/src/app/components/UserEventDetails.tsx
+++ b/src/app/components/UserEventDetails.tsx
@@ -5,6 +5,9 @@ import { Icon } from '@chakra-ui/react'
 import { LuCalendarDays, LuText } from "react-icons/lu";
 import { IoLocationOutline } from "react-icons/io5";
 import { useUser } from "@clerk/nextjs";
+import {
+    SignInButton,
+  } from "@clerk/nextjs";
 
 type IParams = {
   id: string;
@@ -80,7 +83,11 @@ export default function UserEventDetails({ id }: IParams) {
               <button className={style.button}>Sign Up</button>
               ) : 
               (
-              <button className={style.button}>Sign In</button>
+              <SignInButton>
+              <button className={style.button}>
+                  Sign In
+              </button>
+              </SignInButton>
               )}
             </div>
           </div>

--- a/src/app/components/UserEventDetails.tsx
+++ b/src/app/components/UserEventDetails.tsx
@@ -4,6 +4,7 @@ import style from "@styles/UserEventDetails.module.css";
 import { Icon } from '@chakra-ui/react'
 import { LuCalendarDays, LuText } from "react-icons/lu";
 import { IoLocationOutline } from "react-icons/io5";
+import { useUser } from "@clerk/nextjs";
 
 type IParams = {
   id: string;
@@ -11,6 +12,9 @@ type IParams = {
 
 export default function UserEventDetails({ id }: IParams) {
   const [eventData, setEventData] = useState<IEvent | null>(null);
+  
+  //User Session Data
+  const { isLoaded, isSignedIn, user } = useUser();
 
   async function fetchEventData() {
     try {
@@ -72,7 +76,12 @@ export default function UserEventDetails({ id }: IParams) {
               </div>
             </div>
             <div className={style.buttonContainer}>
+              {(user && isSignedIn && isLoaded) ? (
               <button className={style.button}>Sign Up</button>
+              ) : 
+              (
+              <button className={style.button}>Sign In</button>
+              )}
             </div>
           </div>
         </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -37,13 +37,13 @@ export default function Home() {
           alignItems: "center",
           justifyContent: "space-between",
         }}
-      >
+      >    
         <Navbar />
         <div>
           {adminbutton ? (
             <div>
               <Button onClick={() => (admin ? setAdmin(false) : setAdmin(true))} mt={3} p={6} colorScheme="teal">
-                {admin ? <>Admin <br/> Change View</> : <>User <br/> Change View</>}
+                {admin ? <>View as <br/> volunteer</> : <>View as <br/> Admin</>}
               </Button>
             </div>) :
             null}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,25 +1,33 @@
 "use client";
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import Navbar from "@components/Navbar";
 import Calendar from "@components/Calendar";
 import CreateEvent from '@components/CreateEvent/CreateEvent';
 import { useUser } from '@clerk/nextjs';
 import { Button } from '@chakra-ui/react';
 
+
 export default function Home() {
   const [admin, setAdmin] = useState(false);
-  let adminbutton = false;
+  const [adminbutton, setAdminButton] = useState(false);
 
   const { isLoaded, isSignedIn, user } = useUser();
-  const admins = process.env.NEXT_PUBLIC_ADMIN_EMAIL_ADDRESSES?.split(",");
-  if (user && isSignedIn && isLoaded && user.primaryEmailAddress) {
-    if (admins?.includes(user.primaryEmailAddress.emailAddress)) {
-      adminbutton = true;
+
+  useEffect(() => {
+    if (user) {
+      const orgs = user.organizationMemberships;
+      if (orgs?.some(org => org.organization.name === "CCC-USS-Admins")) {
+        setAdminButton(true);
+      } else {
+        setAdminButton(false);
+        setAdmin(false);
+      }
     } else {
-      adminbutton = false;
+      setAdminButton(false);
       setAdmin(false);
     }
-  }
+  },[user, isSignedIn, isLoaded]);
+
   return (
     <main>
       <div

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,9 +3,23 @@ import React, { useState } from 'react';
 import Navbar from "@components/Navbar";
 import Calendar from "@components/Calendar";
 import CreateEvent from '@components/CreateEvent/CreateEvent';
+import { useUser } from '@clerk/nextjs';
+import { Button } from '@chakra-ui/react';
+
 export default function Home() {
   const [admin, setAdmin] = useState(false);
-  
+  let adminbutton = false;
+
+  const { isLoaded, isSignedIn, user } = useUser();
+  const admins = process.env.NEXT_PUBLIC_ADMIN_EMAIL_ADDRESSES?.split(",");
+  if (user && isSignedIn && isLoaded && user.primaryEmailAddress) {
+    if (admins?.includes(user.primaryEmailAddress.emailAddress)) {
+      adminbutton = true;
+    } else {
+      adminbutton = false;
+      setAdmin(false);
+    }
+  }
   return (
     <main>
       <div
@@ -17,10 +31,15 @@ export default function Home() {
         }}
       >
         <Navbar />
-        <div>i am the admin: {admin.toString()}</div>
-        <button onClick={() => (admin ? setAdmin(false) : setAdmin(true))}>
-          secure button
-        </button>
+        <div>
+          {adminbutton ? (
+            <div>
+              <Button onClick={() => (admin ? setAdmin(false) : setAdmin(true))} mt={3} p={6} colorScheme="teal">
+                {admin ? <>Admin <br/> Change View</> : <>User <br/> Change View</>}
+              </Button>
+            </div>) :
+            null}
+        </div>
         <div className="h-screen">
         </div>
         <div style={{ width: "70%", margin: "20px" }}>


### PR DESCRIPTION
## Developer: Ivan Alvarez

Closes #66 

### Pull Request Summary

Changed authentication method from checking env files to now checking if the user is in the CCC-USS Admin org on Clerk. Also, there is now a button for admins to switch between user and admin views while retaining admin status. 

### Modifications

*Calendar.tsx
   - Changed Profile Database button to fully react. Also, different views for admin or user implemented.
*UserEventDetails.tsx
   - Added Button to tell user to sign in if they are not signed in and to sign up for an event if they are.
* Homepage
   - Determines whether a user is an admin and passes bool down to children components to determine views.

### Testing Considerations

Tested signing in and not being in the org, shouldn't show up any admin buttons. Tested signing in and being in org. Tested signing out as admin, removes buttons. Tested signing in and then adding the user to org, buttons show up after reloading.

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers

### Screenshots/Screencast

![image](https://github.com/hack4impact-calpoly/cp-ccc-uss/assets/68352406/c288012e-1b5e-46cb-b61f-9f725915b7c6)
![image](https://github.com/hack4impact-calpoly/cp-ccc-uss/assets/68352406/c507d957-d88d-499c-8411-698d44d4d1a8)
![image](https://github.com/hack4impact-calpoly/cp-ccc-uss/assets/68352406/52bdeb7b-9c67-45d0-bc7f-e4aa84bd59f1)

