### PR TITLE
Add Delete Question on CreateEvent (Closes #79)

### DIFF
--- a/src/app/components/AddQuestions/AddQuestions.tsx
+++ b/src/app/components/AddQuestions/AddQuestions.tsx
@@ -10,25 +10,14 @@ import {
   List,
   ListItem,
   Select,
-  Circle,
 } from "@chakra-ui/react";
 import { DeleteIcon } from "@chakra-ui/icons";
 import { EmptyCircleIcon, PlusCircleIcon } from "../../styles/CustomElements";
-
-//add to parent component
-//const [questions, setQuestions] = useState<IFormQuestion[]>([])
-
-//when adding component
-//<AddQuestions questions={questions} setQuestions={setQuestions}/>
 
 export default function AddQuestions(props: {
   questions: IFormQuestion[];
   setQuestions: Function;
 }) {
-  const [newOptionInputs, setNewOptionInputs] = useState<{
-    [index: number]: string;
-  }>({});
-
   const handleInputChange = (
     e: React.ChangeEvent<HTMLInputElement>,
     index: number
@@ -61,6 +50,12 @@ export default function AddQuestions(props: {
     } else {
       console.error("Options are undefined");
     }
+  };
+
+  const handleDeleteQuestion = (index: number) => {
+    const updatedQuestions = [...props.questions];
+    updatedQuestions.splice(index, 1);
+    props.setQuestions(updatedQuestions);
   };
 
   const handleAddOption = (questionIndex: number) => {
@@ -130,6 +125,12 @@ export default function AddQuestions(props: {
                 <option value="SHORT_ANSWER">Short Answer</option>
               </Select>
             </FormControl>
+            <IconButton
+              aria-label="Delete question"
+              icon={<DeleteIcon />}
+              onClick={() => handleDeleteQuestion(index)}
+              variant="unstyled"
+            />
           </Flex>
 
           <Box>
@@ -160,6 +161,8 @@ export default function AddQuestions(props: {
                         icon={<DeleteIcon />}
                         onClick={() => handleDeleteOption(index, opIndex)}
                         variant="unstyled"
+                        opacity="0.7"
+                        _hover={{ opacity: "1" }}
                       />
                     </ListItem>
                   ))}
@@ -169,7 +172,7 @@ export default function AddQuestions(props: {
                       leftIcon={<PlusCircleIcon />}
                       variant="unstyled"
                       color="customGray"
-                      fontWeight="normal" 
+                      fontWeight="normal"
                       fontStyle={"italic"}
                     >
                       Add option


### PR DESCRIPTION
## Developer: Adrian Nguyen

Closes #79

### Pull Request Summary

Added option to delete questions, some minor styling changes.

### Modifications

- Add handleDeleteQuestion in AddQuestions.tsx.
- Clean up some unused code
- Add some styling to delete icons to differentiate between questions and option delete

### Testing Considerations

It was tested by outputting states. Made a mock event and ensure questions set are still correct after deletions.

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers

### Screenshots/Screencast

![Screenshot 2024-05-22 at 9 45 36 PM](https://github.com/hack4impact-calpoly/cp-ccc-uss/assets/73419144/45a2df3d-6afb-4ab0-8da7-3884b020780c)
