### PR TITLE
Remove Small Description Scroll Bars

### DIFF
--- a/src/app/components/AdminEventDetails/AdminEventDetails.tsx
+++ b/src/app/components/AdminEventDetails/AdminEventDetails.tsx
@@ -133,7 +133,7 @@ export default function AdminEventDetails({ _id }: Props) {
           <Icon as={LuText}
             className={style.icon}
             sx={{ fontSize: 50 }}/>
-          <div style={{marginTop: "10px", overflow: 'scroll', maxHeight: '400px'}}>
+          <div style={{marginTop: "10px", overflowY: 'auto', maxHeight: '400px'}}>
             <strong>Description:{" "}</strong>
             {" " +event.description}
           </div>

--- a/src/app/components/UserEventDetails.tsx
+++ b/src/app/components/UserEventDetails.tsx
@@ -84,7 +84,7 @@ export default function UserEventDetails({ id }: IParams) {
               <Icon as={LuText}
               className={style.icon}
               sx={{ fontSize: 50 }}/>
-              <div style={{marginTop: "10px", overflow: 'scroll', maxHeight: '400px'}}>
+              <div style={{marginTop: "10px", overflowY: 'auto', maxHeight: '400px'}}>
                 <strong>Description:</strong>{" " + eventData.description}
               </div>
             </div>


### PR DESCRIPTION
…ble after 400px of height.

## Developer: Ivan Alvarez

Closes #72 

### Pull Request Summary

Removed scrollbars appearing when a small description was displayed on both event details' modal. 

### Modifications

* UserEventDetails.tsx
  - Changed description styling from overflow to overflowY.
* AdminEventDetails.tsx
  - Changed description styling from overflow to overflowY.

### Testing Considerations

Tested large and smaller descriptions

### Pull Request Checklist

- [ x ] Code is neat, readable, and works
- [ x ] Comments are appropriate
- [ x ] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [ x ] The developer name is specified
- [ x ] The summary is completed
- [ x ] Assign reviewers

### Screenshots/Screencast

![image](https://github.com/hack4impact-calpoly/cp-ccc-uss/assets/68352406/521e057a-342e-4f76-8e80-8637c9f25391)
